### PR TITLE
fix MathJax CDN and cleanup

### DIFF
--- a/content.js
+++ b/content.js
@@ -28,14 +28,16 @@
 
 
 
-// Wrap the span for legacy zoom levels. Could it be an option within the Chrome extension?
+// Wrap the span for legacy zoom levels.
+// Could it be an option within the Chrome extension?
 $('img.tex').each(function() {
   if($(this).parent().is('dd')) {
     $(this).wrap('<span style="font-size: 125%">');
   }
 });
 
-// Wrap images in MathJax_Preview spans and attach the MathJax math script. MathJax will remove the preview when it's done typesetting.
+// Wrap images in MathJax_Preview spans and attach the MathJax math script.
+// MathJax will remove the preview when it's done typesetting.
 $('img.tex').wrap('<span class="MathJax_Preview" />');
 $('.MathJax_Preview').after(function () {
   var $disp, $scale;
@@ -65,7 +67,9 @@ $('.MathJax_Preview').after(function () {
 //      showMathMenu:false,\
 //      styles:{},\
 //    },\
-// Inject config code for MathJax TODO: add texvc macros from https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FMath/0476fd66d5ed73103349ca8c376601656bb2bec9/modules%2FMathJax%2Fextensions%2FTeX%2Ftexvc.js
+// Inject config code for MathJax
+// TODO: add texvc macros from https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FMath/0476fd66d5ed73103349ca8c376601656bb2bec9/modules%2FMathJax%2Fextensions%2FTeX%2Ftexvc.js
+
 $('script').append('<script type="text/x-mathjax-config">\
   MathJax.Hub.Config({\
     displayAlign: "left",\
@@ -124,10 +128,8 @@ $('script').append('<script type="text/x-mathjax-config">\
   });\
 </script>');
 
-// To ensure that we loading MathJax AFTER substituting images, we load it manualy TODO follow Wikipedia's configuration https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FMath/0476fd66d5ed73103349ca8c376601656bb2bec9/modules%2FMathJax%2Fconfig%2FTeX-AMS-texvc_HTML.js
-$('script').append(
-'<script type="text/javascript" \
-src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">\
-</script>');
+// To ensure that we loading MathJax AFTER substituting images, we load it manualy
+// TODO: follow Wikipedia's configuration https://git.wikimedia.org/blob/mediawiki%2Fextensions%2FMath/0476fd66d5ed73103349ca8c376601656bb2bec9/modules%2FMathJax%2Fconfig%2FTeX-AMS-texvc_HTML.js
+$('script').append('<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"></script>');
 
 


### PR DESCRIPTION
- fix deprecated MathJax CDN url (see http://www.mathjax.org/changes-to-the-mathjax-cdn/)
- break comments into multiple lines
