### PR TITLE
Add mhchem extension so chemical equations (\ce) work

### DIFF
--- a/content.js
+++ b/content.js
@@ -51,7 +51,7 @@ var commonConfig = {
   },
   displayAlign : "left",
   TeX : {
-    extensions : ["color.js"],
+    extensions : ["color.js", "mhchem.js"],
   },
   menuSettings : {
     zoom : "Click",


### PR DESCRIPTION
Currently, pages using the `<math chem>`, `<ce>`, or `{{chem}}` wiki markup do not work because the mhchem extension is required for `\ce` to work. (See, for example, the [chemistry examples](https://en.wikipedia.org/wiki/Help:Displaying_a_formula#Chemistry) for the Wikipedia math help.) This fixes that by adding the mhchem extension to the MathJax config in content.js.

Testing this locally, it works on the English Wikipedia on the few pages I tried it on. I haven't tried it on anything else.